### PR TITLE
Add basic Android TV remote support

### DIFF
--- a/app/(auth)/player/direct-player.tsx
+++ b/app/(auth)/player/direct-player.tsx
@@ -43,7 +43,7 @@ import React, {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, Platform, View } from "react-native";
+import { Alert, Platform, View, useTVEventHandler } from "react-native";
 import { useSharedValue } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 const downloadProvider = !Platform.isTV
@@ -75,6 +75,20 @@ export default function page() {
   const progress = useSharedValue(0);
   const isSeeking = useSharedValue(false);
   const cacheProgress = useSharedValue(0);
+  useTVEventHandler((evt) => {
+    if (!Platform.isTV) return;
+    if (evt.eventType === "playPause") {
+      togglePlay();
+    }
+    if (evt.eventType === "rewind" || evt.eventType === "left") {
+      const newTime = Math.max(progress.get() - 10000, 0);
+      videoRef.current?.seekTo(newTime);
+    }
+    if (evt.eventType === "fastForward" || evt.eventType === "right") {
+      const newTime = progress.get() + 10000;
+      videoRef.current?.seekTo(newTime);
+    }
+  });
   const VolumeManager = Platform.isTV
     ? null
     : require("react-native-volume-manager");

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,11 +1,13 @@
 import { useHaptic } from "@/hooks/useHaptic";
 import type React from "react";
 import { type PropsWithChildren, type ReactNode, useMemo } from "react";
-import { Platform, Text, TouchableOpacity, View } from "react-native";
+import { Platform, Text, TouchableOpacity, Pressable, View } from "react-native";
 import { Loader } from "./Loader";
 
+const TouchableComponent = Platform.isTV ? Pressable : TouchableOpacity;
+
 export interface ButtonProps
-  extends React.ComponentProps<typeof TouchableOpacity> {
+  extends React.ComponentProps<typeof TouchableComponent> {
   onPress?: () => void;
   className?: string;
   textClassName?: string;
@@ -16,6 +18,11 @@ export interface ButtonProps
   iconRight?: ReactNode;
   iconLeft?: ReactNode;
   justify?: "center" | "between";
+  hasTVPreferredFocus?: boolean;
+  nextFocusDown?: number;
+  nextFocusUp?: number;
+  nextFocusLeft?: number;
+  nextFocusRight?: number;
 }
 
 export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
@@ -47,7 +54,7 @@ export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
   const lightHapticFeedback = useHaptic("light");
 
   return (
-    <TouchableOpacity
+    <TouchableComponent
       className={`
         p-3 rounded-xl items-center justify-center
         ${(loading || disabled) && "opacity-50"}
@@ -61,6 +68,7 @@ export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
         }
       }}
       disabled={disabled || loading}
+      focusable={Platform.isTV}
       {...props}
     >
       {loading ? (
@@ -88,6 +96,6 @@ export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
           {iconRight ? iconRight : <View className='w-4' />}
         </View>
       )}
-    </TouchableOpacity>
+    </TouchableComponent>
   );
 };

--- a/components/RoundButton.tsx
+++ b/components/RoundButton.tsx
@@ -5,10 +5,13 @@ import type { PropsWithChildren } from "react";
 import {
   Platform,
   TouchableOpacity,
+  Pressable,
   type TouchableOpacityProps,
 } from "react-native";
 
-interface Props extends TouchableOpacityProps {
+const TouchableComponent = Platform.isTV ? Pressable : TouchableOpacity;
+
+interface Props extends React.ComponentProps<typeof TouchableComponent> {
   onPress?: () => void;
   icon?: keyof typeof Ionicons.glyphMap;
   background?: boolean;
@@ -40,9 +43,10 @@ export const RoundButton: React.FC<PropsWithChildren<Props>> = ({
 
   if (fillColor)
     return (
-      <TouchableOpacity
+      <TouchableComponent
         onPress={handlePress}
         className={`rounded-full ${buttonSize} flex items-center justify-center ${fillColorClass}`}
+        focusable={Platform.isTV}
         {...props}
       >
         {icon ? (
@@ -53,14 +57,15 @@ export const RoundButton: React.FC<PropsWithChildren<Props>> = ({
           />
         ) : null}
         {children ? children : null}
-      </TouchableOpacity>
+      </TouchableComponent>
     );
 
   if (background === false)
     return (
-      <TouchableOpacity
+      <TouchableComponent
         onPress={handlePress}
         className={`rounded-full ${buttonSize} flex items-center justify-center ${fillColorClass}`}
+        focusable={Platform.isTV}
         {...props}
       >
         {icon ? (
@@ -71,16 +76,17 @@ export const RoundButton: React.FC<PropsWithChildren<Props>> = ({
           />
         ) : null}
         {children ? children : null}
-      </TouchableOpacity>
+      </TouchableComponent>
     );
 
   if (Platform.OS === "android")
     return (
-      <TouchableOpacity
+      <TouchableComponent
         onPress={handlePress}
         className={`rounded-full ${buttonSize} flex items-center justify-center ${
           fillColor ? fillColorClass : "bg-neutral-800/80"
         }`}
+        focusable={Platform.isTV}
         {...props}
       >
         {icon ? (
@@ -91,11 +97,11 @@ export const RoundButton: React.FC<PropsWithChildren<Props>> = ({
           />
         ) : null}
         {children ? children : null}
-      </TouchableOpacity>
+      </TouchableComponent>
     );
 
   return (
-    <TouchableOpacity onPress={handlePress} {...props}>
+    <TouchableComponent onPress={handlePress} focusable={Platform.isTV} {...props}>
       <BlurView
         intensity={90}
         className={`rounded-full overflow-hidden ${buttonSize} flex items-center justify-center ${fillColorClass}`}
@@ -110,6 +116,6 @@ export const RoundButton: React.FC<PropsWithChildren<Props>> = ({
         ) : null}
         {children ? children : null}
       </BlurView>
-    </TouchableOpacity>
+    </TouchableComponent>
   );
 };

--- a/components/common/TouchableItemRouter.tsx
+++ b/components/common/TouchableItemRouter.tsx
@@ -7,9 +7,16 @@ import type {
 } from "@jellyfin/sdk/lib/generated-client/models";
 import { useRouter, useSegments } from "expo-router";
 import { type PropsWithChildren, useCallback } from "react";
-import { TouchableOpacity, type TouchableOpacityProps } from "react-native";
+import {
+  Platform,
+  TouchableOpacity,
+  Pressable,
+  type TouchableOpacityProps,
+} from "react-native";
 
-interface Props extends TouchableOpacityProps {
+const TouchableComponent = Platform.isTV ? Pressable : TouchableOpacity;
+
+interface Props extends React.ComponentProps<typeof TouchableComponent> {
   item: BaseItemDto;
 }
 
@@ -102,16 +109,17 @@ export const TouchableItemRouter: React.FC<PropsWithChildren<Props>> = ({
     from === "(favorites)"
   )
     return (
-      <TouchableOpacity
+      <TouchableComponent
         onLongPress={showActionSheet}
         onPress={() => {
           const url = itemRouter(item, from);
           // @ts-expect-error
           router.push(url);
         }}
+        focusable={Platform.isTV}
         {...props}
       >
         {children}
-      </TouchableOpacity>
+      </TouchableComponent>
     );
 };

--- a/components/list/ListItem.tsx
+++ b/components/list/ListItem.tsx
@@ -1,14 +1,18 @@
 import { Ionicons } from "@expo/vector-icons";
 import type { PropsWithChildren, ReactNode } from "react";
 import {
+  Platform,
   TouchableOpacity,
+  Pressable,
   type TouchableOpacityProps,
   View,
   type ViewProps,
 } from "react-native";
 import { Text } from "../common/Text";
 
-interface Props extends TouchableOpacityProps, ViewProps {
+const TouchableComponent = Platform.isTV ? Pressable : TouchableOpacity;
+
+interface Props extends React.ComponentProps<typeof TouchableComponent>, ViewProps {
   title?: string | null | undefined;
   value?: string | null | undefined;
   children?: ReactNode;
@@ -17,6 +21,7 @@ interface Props extends TouchableOpacityProps, ViewProps {
   showArrow?: boolean;
   textColor?: "default" | "blue" | "red";
   onPress?: () => void;
+  hasTVPreferredFocus?: boolean;
 }
 
 export const ListItem: React.FC<PropsWithChildren<Props>> = ({
@@ -33,12 +38,13 @@ export const ListItem: React.FC<PropsWithChildren<Props>> = ({
 }) => {
   if (onPress)
     return (
-      <TouchableOpacity
+      <TouchableComponent
         disabled={disabled}
         onPress={onPress}
         className={`flex flex-row items-center justify-between bg-neutral-900 h-11 pr-4 pl-4 ${
           disabled ? "opacity-50" : ""
         }`}
+        focusable={Platform.isTV}
         {...props}
       >
         <ListItemContent
@@ -51,7 +57,7 @@ export const ListItem: React.FC<PropsWithChildren<Props>> = ({
         >
           {children}
         </ListItemContent>
-      </TouchableOpacity>
+      </TouchableComponent>
     );
   return (
     <View


### PR DESCRIPTION
## Summary
- make buttons and other core touchables focusable on TV devices
- expose tv-specific props for buttons and list items
- enable remote control for posters and router items
- handle play/pause and seeking via `useTVEventHandler`

## Testing
- `npm run check` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eabb8ec6c8328988d44acf8ba0fb9